### PR TITLE
remove focusing on No button using TAB

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   </style>
 </head>
 <body>
-  <button id="noBtn">No</button>
+  <button id="noBtn" tabindex="-1">No</button>
   <button id="yesBtn">Yes</button>
 </body>
 </html>


### PR DESCRIPTION
### Issue
- The intention for this website is to make the No button not accessible, but pressing the `Tab` key on the keyboard makes the browser focus on it, thus can be clicked afterwards by pressing `Enter`. Which explains how your crush said no.

### Fix
- Gave the button a tab index of -1 so that you can never focus on it with the tab.

--- 

Hopefully this will make the probability of your crush saying yes a 0.0001% higher.